### PR TITLE
Use `twoway` to do fast subslice search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ debug_is_prod = ["reinda-core/debug_is_prod", "reinda-macros/debug_is_prod"]
 
 [dependencies]
 ahash = "0.6"
-reinda-core = { version = "=0.0.1", path = "core" }
-reinda-macros = { version = "=0.0.1", path = "macros" }
 base64 = "0.13"
 bytes = "1"
+reinda-core = { version = "=0.0.1", path = "core" }
+reinda-macros = { version = "=0.0.1", path = "macros" }
 sha2 = "0.9"
-tokio = { version = "1", features = ["fs", "io-util"] }
 thiserror = "1"
+tokio = { version = "1", features = ["fs", "io-util"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,3 +18,4 @@ debug_is_prod = []
 [dependencies]
 bytes = "1"
 thiserror = "1"
+twoway = "0.2.1"

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -251,7 +251,7 @@ impl Iterator for FragmentSpans<'_> {
 }
 
 fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack.windows(needle.len()).position(|win| win == needle)
+    twoway::find_bytes(haystack, needle)
 }
 
 


### PR DESCRIPTION
This has quite a notable performance impact. In a 3MB bundle.js it took
roughly 400ms to parse the file before this commit. Now it's at most a
few tens of ms.