### PR TITLE
feat: handle path suffix in windows

### DIFF
--- a/macros/src/emit.rs
+++ b/macros/src/emit.rs
@@ -59,6 +59,10 @@ pub(crate) fn emit(input: Input) -> Result<TokenStream, Error> {
                 for entry in glob_walker {
                     let file_path = entry
                         .map_err(|e| err!(@span, "IO error while walking glob paths: {e}"))?;
+                    // skip directories
+                    if file_path.is_dir() {
+                        continue;
+                    }
                     let short_path = file_path.strip_prefix(&base)
                         .unwrap_or(&file_path)
                         .to_str()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, path::PathBuf, sync::Arc};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use bytes::Bytes;
 
@@ -122,12 +126,21 @@ impl<'a> Builder<'a> {
         self.assets.push(EntryBuilder {
             kind: EntryBuilderKind::Glob {
                 http_prefix: http_path.into(),
-                files: glob.files.iter().map(|f| GlobFile {
+                files: glob
+                    .files
+                    .iter()
+                    .map(|f| {
+                        GlobFile {
                     // This should never be `None`
-                    suffix: f.path.strip_prefix(&split_glob.prefix)
-                        .expect("embedded file path does not start with glob prefix"),
+                            suffix: Path::new(f.path)
+                                .strip_prefix(split_glob.prefix)
+                                .expect("embedded file path does not start with glob prefix")
+                                .to_str()
+                                .expect("embedded file path contains invalid UTF-8 characters"),
                     source: f.data_source(),
-                }).collect(),
+                        }
+                    })
+                    .collect(),
                 glob: split_glob,
                 #[cfg(dev_mode)]
                 base_path: glob.base_path,


### PR DESCRIPTION
fix #5 

this pr fix the follow case:

``` rust
const ASSETS: Embeds = embed! {
    base_path: "assets",
    files: ["static/*", "static/js/*", "static/**/*"],
};

pub async fn get_assets() -> Assets {
    let mut builder = Assets::builder();
    builder.add_embedded("test3/", &ASSETS["static/*"]);
    builder.add_embedded("test1/", &ASSETS["static/js/*"]);
    builder.add_embedded("test2/", &ASSETS["static/**/*"]);
    builder.build().await.expect("Failed to initialize assets")
}
```

- `static/*` will match folder
- in windows, `static/js/` will be split to `static/js/`, but `f.path` will parse like this: `static\js\something.js`
- in windows and `static/**/*` glob, `http_path` will get hash key like this: `static/js\something.js`

